### PR TITLE
Improve help command, add --version and --json

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@ version: 2
 builds:
   - main: ./main.go
     binary: kudasai
+    ldflags:
+      - -s -w -X github.com/vibaiher/kudasai/pkg/kudasai.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/examples/help.txt
+++ b/examples/help.txt
@@ -1,2 +1,9 @@
+$ echo '{"commands":{"build": "go build", "test": "go test"}}' > .kudasai.json
 $ kudasai help
 Usage: kudasai [command]
+
+Available commands:
+  build
+  help
+  start
+  test

--- a/pkg/kudasai/kudasai.go
+++ b/pkg/kudasai/kudasai.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 )
+
+var Version = "dev"
 
 type Commands map[string]string
 type KudasaiConfig struct {
@@ -19,7 +22,7 @@ type KudasaiConfig struct {
 func KudasaiDefaultCommands() Commands {
 	return Commands{
 		"start": "echo \"sushi, kudasai\"",
-		"help":  "echo \"Usage: kudasai [command]\"",
+		"help":  "",
 	}
 }
 
@@ -30,21 +33,21 @@ func mergeMaps(map1, map2 map[string]string) map[string]string {
 	return map1
 }
 
-func GetCommands(filepath string) Commands {
+func GetCommands(filepath string) (Commands, bool) {
 	configFile, err := os.Open(filepath)
 	if err != nil {
-		return KudasaiDefaultCommands()
+		return KudasaiDefaultCommands(), false
 	}
 	defer configFile.Close()
 
 	content, err := io.ReadAll(configFile)
 	if err != nil {
-		return KudasaiDefaultCommands()
+		return KudasaiDefaultCommands(), false
 	}
 	var config KudasaiConfig
 	json.Unmarshal(content, &config)
 
-	return mergeMaps(KudasaiDefaultCommands(), config.Commands)
+	return mergeMaps(KudasaiDefaultCommands(), config.Commands), true
 }
 
 func ShellQuote(arg string) string {
@@ -110,12 +113,72 @@ func Prepare(command string) *exec.Cmd {
 	return cmd
 }
 
+func Help(commands Commands, configFound bool) {
+	fmt.Println("Usage: kudasai [command]")
+	fmt.Println()
+
+	if !configFound {
+		fmt.Println("Warning: no .kudasai.json found in current directory")
+		fmt.Println()
+		fmt.Println("Built-in commands:")
+	} else {
+		fmt.Println("Available commands:")
+	}
+
+	names := make([]string, 0, len(commands))
+	for name := range commands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		fmt.Printf("  %s\n", name)
+	}
+}
+
+func JSONOutput(commands Commands) error {
+	defaults := KudasaiDefaultCommands()
+
+	output := make(map[string]interface{})
+	cmds := make(map[string]interface{})
+
+	for name, cmd := range commands {
+		if _, isBuiltin := defaults[name]; isBuiltin {
+			cmds[name] = map[string]interface{}{"builtin": true}
+		} else {
+			cmds[name] = map[string]interface{}{"run": cmd}
+		}
+	}
+
+	output["commands"] = cmds
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
 func Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("No arguments provided")
 	}
 
-	commands := GetCommands("./.kudasai.json")
+	switch args[0] {
+	case "--version", "version":
+		fmt.Printf("kudasai %s\n", Version)
+		return nil
+	case "--json":
+		commands, _ := GetCommands("./.kudasai.json")
+		return JSONOutput(commands)
+	case "help", "--help":
+		commands, configFound := GetCommands("./.kudasai.json")
+		Help(commands, configFound)
+		return nil
+	}
+
+	commands, _ := GetCommands("./.kudasai.json")
 	command, exists := commands[args[0]]
 	if !exists {
 		return fmt.Errorf("Unrecognized command: %s", args[0])

--- a/tests/kudasai_test.go
+++ b/tests/kudasai_test.go
@@ -21,10 +21,17 @@ func TestRun_Help(t *testing.T) {
 	}
 }
 
+func TestRun_HelpFlag(t *testing.T) {
+	err := kudasai.Run([]string{"--help"})
+	if err != nil {
+		t.Errorf("Did not expect an error when running --help")
+	}
+}
+
 func TestRun_Start(t *testing.T) {
 	err := kudasai.Run([]string{"start"})
 	if err != nil {
-		t.Errorf("Did not expect an error when running the help command")
+		t.Errorf("Did not expect an error when running the start command")
 	}
 }
 
@@ -32,6 +39,27 @@ func TestRun_InvalidCommand(t *testing.T) {
 	err := kudasai.Run([]string{"invalid"})
 	if err == nil {
 		t.Errorf("Expected an error for an unrecognized command")
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	err := kudasai.Run([]string{"--version"})
+	if err != nil {
+		t.Errorf("Did not expect an error when running --version")
+	}
+}
+
+func TestRun_VersionSubcommand(t *testing.T) {
+	err := kudasai.Run([]string{"version"})
+	if err != nil {
+		t.Errorf("Did not expect an error when running version")
+	}
+}
+
+func TestRun_JSON(t *testing.T) {
+	err := kudasai.Run([]string{"--json"})
+	if err != nil {
+		t.Errorf("Did not expect an error when running --json")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace shell-based `help` with native Go that lists available commands (with warning when no `.kudasai.json` found)
- Add `--version` / `version` flag with ldflags support for GoReleaser
- Add `--json` flag for structured JSON output (marks built-in commands with `"builtin": true`)
- Add `--help` as alias for `help`

## Test plan
- [x] `go test -v ./tests/...` — all 17 unit tests pass
- [x] `bash scripts/acceptance.sh` — all 10 acceptance tests pass
- [x] Manual verification of `kudasai help`, `--version`, `version`, `--json`
- [x] Test `kudasai help` without `.kudasai.json` shows warning + built-in commands

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)