### PR TITLE
Fix acceptance tests PATH shadowing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
         chmod +x clitest
-    - name: Install kudasai binary
-      run: go install
-    - name: Run acceptance test
-      run: ./clitest examples/**
+        sudo mv clitest /usr/local/bin/
+    - name: Run acceptance tests
+      run: bash scripts/acceptance.sh

--- a/.kudasai.json
+++ b/.kudasai.json
@@ -1,6 +1,7 @@
 {
     "commands": {
         "build": "go build -o kudasai main.go",
-        "test": "go test -v ./tests/..."
+        "test": "go test -v ./tests/...",
+        "acceptance": "bash scripts/acceptance.sh"
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ go test -v ./tests/...              # Run unit tests
 go test -v -run TestRun_Help ./tests/...  # Run a single test by name
 ```
 
-Acceptance tests require the binary to be installed first:
+Acceptance tests:
 ```bash
-go install && clitest examples/**   # Run acceptance tests (requires clitest)
+kudasai acceptance                   # Run acceptance tests (requires clitest)
 ```
 
 ### Prerequisites

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Build binary to temp dir
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+go build -o "$tmpdir/kudasai" main.go
+
+# Run clitest from temp dir so .kudasai.json writes go there
+(cd "$tmpdir" && PATH="$tmpdir:$PATH" clitest "$OLDPWD"/examples/**)


### PR DESCRIPTION
## Summary
- Build the binary to a temp directory and run clitest from there, so acceptance tests don't depend on system PATH order
- Add `scripts/acceptance.sh` and a `kudasai acceptance` command for convenience
- Update CI workflow to use the new script

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)