### PR TITLE
fix: propagate exit codes from executed commands

### DIFF
--- a/examples/exit-code.txt
+++ b/examples/exit-code.txt
@@ -1,0 +1,3 @@
+$ echo '{"commands":{"fail": "exit 42"}}' > .kudasai.json
+$ kudasai fail; echo $?
+42

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/vibaiher/kudasai/pkg/kudasai"
 )
@@ -12,6 +14,10 @@ func main() {
 
 	err := kudasai.Run(args)
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/kudasai/kudasai.go
+++ b/pkg/kudasai/kudasai.go
@@ -186,10 +186,6 @@ func Run(args []string) error {
 
 	command = InterpolateArgs(command, args[1:])
 
-	err := Execute(command)
-	if err != nil {
-		return fmt.Errorf("Unexpected error: %s", err)
-	}
-	return nil
+	return Execute(command)
 
 }

--- a/tests/kudasai_test.go
+++ b/tests/kudasai_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/vibaiher/kudasai/pkg/kudasai"
@@ -124,6 +126,22 @@ func TestInterpolateArgs_MissingPositionalArg(t *testing.T) {
 	expected := "echo 'hello' and "
 	if result != expected {
 		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestExecute_PropagatesExitCode(t *testing.T) {
+	err := kudasai.Execute("exit 42")
+	if err == nil {
+		t.Fatal("Expected an error for non-zero exit code")
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Expected exec.ExitError, got %T", err)
+	}
+
+	if exitErr.ExitCode() != 42 {
+		t.Errorf("Expected exit code 42, got %d", exitErr.ExitCode())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Propagate the original exit code from executed commands instead of always exiting with 1
- `Execute()` now returns the raw error from `cmd.Run()`, and `main.go` extracts the exit code via `exec.ExitError`

## Test plan
- [x] Unit test: `TestExecute_PropagatesExitCode` verifies exit code 42 is preserved
- [x] Acceptance test: `examples/exit-code.txt` verifies end-to-end exit code propagation
- [x] All 18 unit tests and 12 acceptance tests pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)